### PR TITLE
Add Docker setup for local API usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+docker-compose.yml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ Thumbs.db
 tokens.encrypted.json
 
 # Docker
-.dockerignore
 
 # Temporary files
 tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 7777
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  api:
+    build: .
+    ports:
+      - "${PORT:-7777}:7777"
+    env_file:
+      - .env
+    environment:
+      TIKTOK_CLIENT_KEY: ${TIKTOK_CLIENT_KEY}
+      TIKTOK_CLIENT_SECRET: ${TIKTOK_CLIENT_SECRET}
+      TIKTOK_REDIRECT_URI: ${TIKTOK_REDIRECT_URI:-http://localhost:7777/auth/callback}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      PORT: ${PORT:-7777}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 
 const app = express();
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 7777;
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose to run OAuth2 server in a container
- default server port to 7777 when `PORT` env is absent
- add Docker ignore rules for cleaner images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf3f88a14832f8f109d6240a14d7b