### PR TITLE
feat: mount host video directory for Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+docker-compose.yml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ Thumbs.db
 tokens.encrypted.json
 
 # Docker
-.dockerignore
 
 # Temporary files
 tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 7777
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ I created this mostly to workaround the issue of n8n TikTok OAuth2 flow not work
 
 #### Example Workflow
 
+When running with Docker, set the `VIDEO_DIR` variable in your `.env` file. That directory on your host is mounted into the container at `/videos`. Use paths within `/videos` when referencing files.
+
 ```bash
 # One-time OAuth2 authentication
 curl http://localhost:7777/auth/login
@@ -48,7 +50,7 @@ curl -X GET http://localhost:7777/creator-info
 curl -X POST http://localhost:7777/video/upload \
   -H "Content-Type: application/json" \
   -d '{
-    "file_path": "/home/user/videos/my_video.mp4",
+    "file_path": "/videos/my_video.mp4",
   }'
 
 # and check upload status at (replace with actual publish_id):
@@ -86,7 +88,7 @@ const uploadResponse = await fetch('http://localhost:7777/video/upload', {
     'Content-Type': 'application/json'
   },
   body: JSON.stringify({
-    file_path: '/path/to/video.mp4',
+    file_path: '/videos/my_video.mp4',
   })
 });
 const uploadData = await uploadResponse.json();
@@ -129,6 +131,7 @@ Then edit `.env` with your credentials:
 | `TIKTOK_REDIRECT_URI` | ✅ | OAuth2 redirect URI. Where TikTok will send redirect info (eg. http://localhost:7777/auth/callback) |
 | `PORT` | ❌ | Server port (default: 7777) |
 | `ENCRYPTION_KEY` | ❌ | Encryption key for token storage |
+| `VIDEO_DIR` | ❌ | Host directory with videos to mount at `/videos` in the container |
 
 
 ### 4. Start the Server
@@ -142,6 +145,14 @@ npm start
 ```
 
 Visit `http://localhost:[port]/auth/login` to start the OAuth2 flow!
+
+### Run with Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The directory specified in `VIDEO_DIR` will be available inside the container at `/videos`. Use that path when providing `file_path` values to the upload endpoint.
 
 
 ### Server Management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  api:
+    build: .
+    ports:
+      - "${PORT:-7777}:7777"
+    env_file:
+      - .env
+    environment:
+      TIKTOK_CLIENT_KEY: ${TIKTOK_CLIENT_KEY}
+      TIKTOK_CLIENT_SECRET: ${TIKTOK_CLIENT_SECRET}
+      TIKTOK_REDIRECT_URI: ${TIKTOK_REDIRECT_URI:-http://localhost:7777/auth/callback}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      PORT: ${PORT:-7777}
+    volumes:
+      - "${VIDEO_DIR:-./videos}:/videos:ro"

--- a/env.example
+++ b/env.example
@@ -5,4 +5,6 @@ TIKTOK_REDIRECT_URI=http://localhost:7777/auth/callback
 ENCRYPTION_KEY=your-super-secret-encryption-key-here
 
 # Server Configuration
-PORT=7777 
+PORT=7777
+# Directory on host containing videos to mount into the container
+VIDEO_DIR=./videos

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 
 const app = express();
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 7777;
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
## Summary
- mount host video directory into container via `VIDEO_DIR` volume
- document new `VIDEO_DIR` option and Docker usage in README
- provide example paths using mounted `/videos` directory

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf3f88a14832f8f109d6240a14d7b