### PR TITLE
feat: add 10MB chunked video uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ curl "http://localhost:7777/video/status?publish_id=abc123def456"
 This backend implements video upload function following TikTok's two-step process:
 
 1. **Initialize Upload**: The server calls TikTok's initialization endpoint with video metadata
-2. **Upload File**: The video file is uploaded to TikTok's designated URL
+2. **Upload File**: The video file is uploaded to TikTok's designated URL in 10MB chunks using `Content-Range` headers
 3. **Status Tracking**: Use the returned `publish_id` to track upload progress
+
+Each chunk is 10MB (the final or only chunk may be smaller if the file is less than 10MB) to comply with TikTok's upload requirements.
 
 (Video upload works fine by direct video posting only supports private posting. Reason [here](https://community.n8n.io/t/http-request-node-not-sending-authorization-header-despite-selecting-connected-oauth2-credential-tiktok-api/99963/4) and [here](https://developers.tiktok.com/doc/content-sharing-guidelines#:~:text=Not%20acceptable%3A%20A%20utility%20tool%20to%20help%20upload%20contents%20to%20the%20account(s)%20you%20or%20your%20team%20manages.%20%E2%9D%8C))
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const crypto = require('crypto');
 const SecureTokenStorage = require('./tokenStorage');
 const fs = require('fs');
 const path = require('path');
+// Fixed chunk size for video uploads (10MB)
+const CHUNK_SIZE = 10 * 1024 * 1024;
 
 const app = express();
 const PORT = process.env.PORT || 7777;
@@ -265,8 +267,11 @@ app.post('/video/direct-post', async (req, res) => {
     // Get file stats
     const stats = fs.statSync(file_path);
     const fileSize = stats.size;
-    const chunkSize = (fileSize < 10 * 1024 * 1024) ? fileSize : 10 * 1024 * 1024; // 10MB chunks
-    const totalChunkCount = Math.ceil(fileSize / chunkSize);
+    const chunkSize = Math.min(CHUNK_SIZE, fileSize);
+    let totalChunkCount = 0;
+    for (let offset = 0; offset < fileSize; offset += chunkSize) {
+      totalChunkCount++;
+    }
 
     // Step 1: Initialize video upload
     console.log('Initializing video upload...');
@@ -299,19 +304,24 @@ app.post('/video/direct-post', async (req, res) => {
     const { publish_id, upload_url } = initResponse.data.data;
     console.log('Upload initialized:', { publish_id, upload_url });
 
-    // Step 2: Upload video file to TikTok's designated URL
-    console.log('Uploading video file...');
-    const videoBuffer = fs.readFileSync(file_path);
-    
-    const uploadResponse = await axios.put(upload_url, videoBuffer, {
-      headers: {
-        'Content-Range': `bytes 0-${fileSize - 1}/${fileSize}`,
-        'Content-Type': 'video/mp4',
-        'Content-Length': fileSize
-      },
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity
-    });
+    // Step 2: Upload video file in chunks
+    console.log('Uploading video file in chunks...');
+    let offset = 0;
+    const stream = fs.createReadStream(file_path, { highWaterMark: chunkSize });
+    for await (const chunk of stream) {
+      const start = offset;
+      const end = offset + chunk.length - 1;
+      await axios.put(upload_url, chunk, {
+        headers: {
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Content-Type': 'video/mp4',
+          'Content-Length': chunk.length
+        },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity
+      });
+      offset += chunk.length;
+    }
 
     console.log('Video upload requested. Check status at http://localhost:${PORT}/video/status?publish_id=${publish_id}');
 
@@ -387,8 +397,11 @@ app.post('/video/upload', async (req, res) => {
     // Get file stats
     const stats = fs.statSync(file_path);
     const fileSize = stats.size;
-    const chunkSize = (fileSize < 10 * 1024 * 1024) ? fileSize : 10 * 1024 * 1024; // 10MB chunks
-    const totalChunkCount = Math.ceil(fileSize / chunkSize);
+    const chunkSize = Math.min(CHUNK_SIZE, fileSize);
+    let totalChunkCount = 0;
+    for (let offset = 0; offset < fileSize; offset += chunkSize) {
+      totalChunkCount++;
+    }
 
     console.log('Starting video upload process...');
     console.log('File info:', { path: file_path, size: fileSize, size_mb: (fileSize / 1024 / 1024).toFixed(2) });
@@ -416,32 +429,25 @@ app.post('/video/upload', async (req, res) => {
     const { publish_id, upload_url } = initResponse.data.data;
     console.log('Upload initialized:', { publish_id, upload_url });
 
-    // Step 2: Upload video file to TikTok's designated URL
-    console.log('Step 2: Uploading video file...');
-    console.log('Upload URL:', upload_url);
-    console.log('File size:', fileSize, 'bytes');
-    console.log('Content-Range:', `bytes 0-${fileSize - 1}/${fileSize}`);
-    console.log('Content-Length:', fileSize);
-    
-    const videoBuffer = fs.readFileSync(file_path);
-    console.log('Video buffer loaded, size:', videoBuffer.length, 'bytes');
-    
-    const uploadHeaders = {
-      'Content-Range': `bytes 0-${fileSize - 1}/${fileSize}`,
-      'Content-Type': 'video/mp4',
-      'Content-Length': fileSize
-    };
-    console.log('Upload headers:', uploadHeaders);
-    
-    const uploadResponse = await axios.put(upload_url, videoBuffer, {
-      headers: uploadHeaders,
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity
-    });
+    // Step 2: Upload video file in chunks to TikTok's designated URL
+    console.log('Step 2: Uploading video file in chunks...');
+    let offset = 0;
+    const stream = fs.createReadStream(file_path, { highWaterMark: chunkSize });
+    for await (const chunk of stream) {
+      const start = offset;
+      const end = offset + chunk.length - 1;
+      await axios.put(upload_url, chunk, {
+        headers: {
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Content-Type': 'video/mp4',
+          'Content-Length': chunk.length
+        },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity
+      });
+      offset += chunk.length;
+    }
 
-    console.log('Upload response status:', uploadResponse.status);
-    console.log('Upload response headers:', uploadResponse.headers);
-    console.log('Upload response data:', uploadResponse.data);
     console.log('Video uploaded to inbox successfully');
 
     // Return success response with publish_id


### PR DESCRIPTION
## Summary
- read video files in 10MB chunks and upload sequentially
- derive total_chunk_count from actual chunk count
- document chunk size and chunked upload in README

## Testing
- `node --check index.js`
- `npm test`
- `npm run lint`
- `node -e "...edge case single chunk test..."`


------
https://chatgpt.com/codex/tasks/task_e_68ad03059fb8832faebc491ecf30c9f5